### PR TITLE
updated upstream url

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 require "open3"
 
 BREW_INSTALL_COMMAND = <<"EOS"
-ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 EOS
 
 namespace :brew do


### PR DESCRIPTION
tried rake brew:setup and got shown below on vanilla OS X Yosemite 10.10.2

```
90202668n:Brewfile jun.morimoto$ rake brew:setup
[EXEC] ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
[DONE] ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
```

so fixed upstream url on Rakefile. thanks in advance.